### PR TITLE
Replace `Commands` with `Service` and `ServiceStore`

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -7,9 +7,8 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strings"
 	"syscall"
-
-	log "github.com/Sirupsen/logrus"
 )
 
 // Status represents the current command status
@@ -25,27 +24,33 @@ const (
 	StatusStopped  Status = "stopped"
 )
 
-// Command represents a os level command, which can also
-// receive a logger file in order to dump the output to it.
+// Command represents a os level command, which can also receive a logger file
+// in order to dump the output to it.
 type Command struct {
 	Log io.WriteCloser
 	Cmd *exec.Cmd
 
-	// stderr *bytes.Buffer // Maybe this will help us debugging when a command fails?
-
-	Slug    string
 	Version string
-
-	status Status
-
 	Updater Updater
 
-	ExecName string
-	ExecArgs []string
+	// Maybe this will help us debugging when a command fails?
+	// stderr *bytes.Buffer
+
+	status   Status
+	execName string
+	execArgs []string
 }
 
-// Updater knows how to update the codebase of a specific
-// command codebase.
+// Clone clones the command by instantiate a new one with same attributes
+// and returns it. This is handy if you need to restart the process, first
+// you stop it, then clone it, then you start the new cloned process.
+func (c *Command) Clone() *Command {
+	cmd := NewCommand(c.Log, c.Version, c.execName, c.execArgs...)
+	cmd.Updater = c.Updater
+	return cmd
+}
+
+// Updater knows how to update the codebase of a specific command codebase.
 type Updater interface {
 	Update() (newVersion string, err error)
 }
@@ -57,10 +62,16 @@ func (c *Command) MarshalJSON() ([]byte, error) {
 		Version string `json:"version"`
 		Status  Status `json:"status"`
 	}{
-		Slug:    c.Slug,
+		Slug:    c.Slug(),
 		Status:  c.Status(),
 		Version: c.Version,
 	})
+}
+
+// Slug combines the command execName and execArgs in order to return a verbose
+// identifier.
+func (c *Command) Slug() string {
+	return fmt.Sprintf("%s %s", c.execName, strings.Join(c.execArgs, " "))
 }
 
 // SetStatus sets the command current status
@@ -68,16 +79,14 @@ func (c *Command) SetStatus(status Status) {
 	c.status = status
 }
 
-// Update uses the updater in order to update the code base
-// and the command version.
-// If no updater is found, it returns an error.
-// Update function returns a boolean that indicates
-// if the code was either updated or not. Knowing if
-// the command was updated is important in order to
-// decide if we need to restart it or not.
+// Update uses the updater in order to update the code base and the command
+// version.  If no updater is found, it returns an error. Update function
+// returns a boolean that indicate if the code was either updated or not.
+// Knowing if the command was updated is important in order to decide if we
+// need to restart it or not.
 func (c *Command) Update() (updated bool, err error) {
 	if c.Updater == nil {
-		return false, fmt.Errorf("command: no updater for %q command", c.Slug)
+		return false, fmt.Errorf("command: no updater for %q command", c.Slug())
 	}
 
 	oldVersion := c.Version
@@ -91,13 +100,10 @@ func (c *Command) Update() (updated bool, err error) {
 		updated = true
 	}
 
-	c.logger().Debugf("updated: %v - oldVersion: %q - newVersion: %q", updated, oldVersion, newVersion)
-
 	return updated, nil
 }
 
-// Status check the command's process state and returns
-// a verbose status.
+// Status check the command's process state and returns a verbose status.
 func (c *Command) Status() Status {
 	if c.Cmd.ProcessState == nil {
 		return c.status
@@ -116,9 +122,8 @@ func (c *Command) Status() Status {
 	return c.status
 }
 
-// CloseLog safely close the command's logger.
-// If the logger is just os.Stdout, it does not
-// close it.
+// CloseLog safely close the command's logger. If the logger is just os.Stdout,
+// it does not close it.
 func (c *Command) CloseLog() error {
 	if c.Log == nil || c.Log == os.Stdout {
 		return nil
@@ -127,26 +132,24 @@ func (c *Command) CloseLog() error {
 	return c.Log.Close()
 }
 
-// Stop stops the command and closes the log file
-// if exists.
+// Stop stops the command and closes the log file if exists.
 func (c *Command) Stop() error {
 	if c.Log != nil {
 		defer c.CloseLog()
 	}
 
 	if c.status == StatusStopped {
-		return fmt.Errorf("commands: command %q is already stopped", c.Slug)
+		return fmt.Errorf("commands: command %q is already stopped", c.Slug())
 	}
 
 	c.status = StatusStopped
 
-	c.logger().Info("Killing process")
 	if c.Cmd.Process == nil {
 		return nil
 	}
 
-	// the ProcessState only exists if either the process exited,
-	// or we called Run or Wait functions.
+	// the ProcessState only exists if either the process exited, or we called
+	// Run or Wait functions.
 	ps := c.Cmd.ProcessState
 	if ps != nil && ps.Exited() {
 		return nil
@@ -160,15 +163,13 @@ func (c *Command) Stop() error {
 	return err
 }
 
-// Wait only proxies the function call to the
-// os.Command.Wait function.
+// Wait only proxies the function call to the  os.Command.Wait function.
 func (c *Command) Wait() error {
 	return c.Cmd.Wait()
 }
 
-// Start starts the process and pipes the command's
-// output to the log file. If at any point there is an error
-// it also closes the file if exists.
+// Start starts the process and pipes the command's output to the log file.
+// If at any point there is an error it also closes the file if exists.
 func (c *Command) Start() error {
 	if c.Log == os.Stdout || c.Log == nil {
 		c.Cmd.Stdout = c.Log
@@ -196,7 +197,6 @@ func (c *Command) Start() error {
 		}()
 	}
 
-	c.logger().Info("Starting")
 	if err := c.Cmd.Start(); err != nil {
 		c.CloseLog()
 		return err
@@ -207,30 +207,21 @@ func (c *Command) Start() error {
 	return nil
 }
 
-func (c *Command) logger() *log.Entry {
-	return log.WithFields(log.Fields{
-		"command": c.Slug,
-		"version": c.Version,
-	})
-}
-
-// Success just proxies the function call to the
-// command.ProcessState struct.
+// Success just proxies the function call to the command.ProcessState struct.
 func (c *Command) Success() bool {
 	return c.Cmd.ProcessState.Success()
 }
 
 // NewCommand returns an initalized command pointer.
-func NewCommand(log io.WriteCloser, slug, version, name string, args ...string) *Command {
+func NewCommand(log io.WriteCloser, version, name string, args ...string) *Command {
 	cmd := &Command{
 		Log:     log,
 		Cmd:     exec.Command(name, args...),
-		Slug:    slug,
 		Version: version,
 
 		status:   StatusIdle,
-		ExecName: name,
-		ExecArgs: args,
+		execName: name,
+		execArgs: args,
 	}
 
 	cmd.Cmd.SysProcAttr = &syscall.SysProcAttr{
@@ -248,7 +239,5 @@ type noopUpdater struct {
 }
 
 func (nu *noopUpdater) Update() (string, error) {
-	nu.logger().Warn("Noop Updater Called")
-
 	return nu.Version, nil
 }

--- a/command/command.go
+++ b/command/command.go
@@ -99,17 +99,11 @@ func (c *Command) Update(updater Updater) (updated bool, err error) {
 
 // Status check the command's process state and returns a verbose status.
 func (c *Command) Status() Status {
-	if c.Cmd.ProcessState == nil {
-		return c.status
-	}
+	if ps := c.Cmd.ProcessState; ps != nil {
+		if ps.Success() {
+			return StatusDone
+		}
 
-	ps := c.Cmd.ProcessState
-
-	if ps.Success() {
-		return StatusDone
-	}
-
-	if ps.Exited() {
 		return StatusError
 	}
 

--- a/git/repo.go
+++ b/git/repo.go
@@ -132,11 +132,10 @@ func (r *Repo) runPostReceiveHooks() error {
 	return nil
 }
 
-// Bootstrap clones the repo if it not exists and runs the
-// post-receive hooks. If there is no errors, it updates the
-// repository current head sha. If the repo is already cloned,
-// the function receives an arguments that indicates if we want
-// to update (git pull) the repo or not.
+// Bootstrap clones the repo if it not exists and runs the post-receive hooks.
+// If there is no errors, it updates the repository current head sha. If the
+// repo is already cloned, the function receives an arguments that indicates
+// if we want to update (git pull) the repo or not.
 func (r *Repo) Bootstrap(wantToUpdate bool) error {
 	updated := false
 
@@ -149,7 +148,7 @@ func (r *Repo) Bootstrap(wantToUpdate bool) error {
 		logger := r.logger()
 
 		logger.Info("Clonning...")
-		clone := exec.Command("git", "clone", "--single-branch", "--branch", "master", r.Remote)
+		clone := exec.Command("git", "clone", "--single-branch", "--branch", "master", r.Remote, r.Path)
 		clone.Dir = path.Dir(r.Path)
 
 		if err := clone.Run(); err != nil {
@@ -199,8 +198,8 @@ func (r *Repo) updateHead() error {
 	return nil
 }
 
-// AddPostReceiveHooks receives one or multiple PostReceiveHooks
-// and appends them to the repo `postReceiveHooks` private attribute.
+// AddPostReceiveHooks receives one or multiple PostReceiveHooks and appends
+// them to the repo `postReceiveHooks` private attribute.
 func (r *Repo) AddPostReceiveHooks(handlers ...PostReceiveHook) {
 	r.postReceiveHooks = append(r.postReceiveHooks, handlers...)
 }
@@ -209,8 +208,8 @@ func sanitizeOutput(b []byte) string {
 	return string(bytes.TrimSpace(b))
 }
 
-// NpmInstallHook is a PostReceiveHook preset that runs
-// a `npm install --production` command.
+// NpmInstallHook is a PostReceiveHook preset that runs a
+// `npm install --production` command.
 func NpmInstallHook(r *Repo) error {
 	npmInstall := exec.Command("npm", "install", "--production")
 	npmInstall.Dir = r.Path
@@ -219,8 +218,7 @@ func NpmInstallHook(r *Repo) error {
 	return npmInstall.Run()
 }
 
-// NpmPruneHook is a PostReceiveHook preset that runs
-// a `npm prune` command.
+// NpmPruneHook is a PostReceiveHook preset that runs a `npm prune` command.
 func NpmPruneHook(r *Repo) error {
 	prune := exec.Command("npm", "prune")
 	prune.Dir = r.Path

--- a/main.go
+++ b/main.go
@@ -83,7 +83,6 @@ func main() {
 	// ----- Initialize commands
 	wisebotCoreCommand := command.NewCommand(
 		nil,
-		wisebotServiceName,
 		wisebotCoreRepo.CurrentHead(),
 		"node",
 		wisebotCoreRepoExpandedPath+"/build/app/index.js",

--- a/main.go
+++ b/main.go
@@ -64,8 +64,6 @@ func init() {
 	check(err)
 
 	healthzPublishableTopic = fmt.Sprintf("/operator/%s/healthz", wisebotConfig.WisebotID)
-
-	services = make(ServiceStore)
 }
 
 func main() {
@@ -90,7 +88,7 @@ func main() {
 	// TODO: add ble command
 
 	// Append services to global store
-	services.Add(wisebotServiceName, wisebotCoreCommand, wisebotCoreRepo)
+	services.Save(wisebotServiceName, wisebotCoreCommand, wisebotCoreRepo)
 
 	// ----- Initialize MQTT connection
 	cert, err := wisebotConfig.getTLSCertificate()

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ const (
 	// wisebotCoreRepoPath    = "~/wisebot-core"
 	// wisebotCoreRepoRemote  = "git@github.com:wisegrowth/wisebot-core.git"
 	wisebotServiceName    = "wisebot-test"
-	wisebotCoreRepoPath   = "~/Code/wg/test"
+	wisebotCoreRepoPath   = "~/wisebot-test"
 	wisebotCoreRepoRemote = "git@github.com:wisegrowth/test.git"
 
 	bleServiceName = "wisebot-ble"

--- a/main.go
+++ b/main.go
@@ -101,7 +101,11 @@ func main() {
 	check(err)
 
 	// ----- Start application
-	check(services.Start())
+	if err := services.Start(); err != nil {
+		services.Stop()
+		check(err)
+	}
+
 	check(client.Connect())
 
 	// ----- Subscribe to MQTT topics

--- a/services.go
+++ b/services.go
@@ -18,7 +18,6 @@ type Service struct {
 }
 
 func newService(name string, c *command.Command, r *git.Repo) *Service {
-	c.Updater = r
 	return &Service{Name: name, cmd: c, repo: r}
 }
 
@@ -39,7 +38,7 @@ func (s *Service) MarshalJSON() ([]byte, error) {
 
 // Update proxies function to the its command
 func (s *Service) Update() (bool, error) {
-	return s.cmd.Update()
+	return s.cmd.Update(s.repo)
 }
 
 // ServiceStore represents a set of commands.
@@ -83,7 +82,7 @@ func (ss *ServiceStore) Update(name string) error {
 
 	svc.logger().Info("Running update")
 	cmd.SetStatus(command.StatusUpdating)
-	updated, err := cmd.Update()
+	updated, err := svc.Update()
 	if err != nil {
 		svc.cmd.SetStatus(command.StatusRunning)
 		return err

--- a/services.go
+++ b/services.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/WiseGrowth/wisebot-operator/command"
+	"github.com/WiseGrowth/wisebot-operator/git"
+)
+
+// Service encapsulates a command an its repository
+type Service struct {
+	Name string
+	cmd  *command.Command
+	repo *git.Repo
+}
+
+func newService(name string, c *command.Command, r *git.Repo) *Service {
+	c.Updater = r
+	return &Service{Name: name, cmd: c, repo: r}
+}
+
+// MarshalJSON implements json marshal interface
+func (s *Service) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Name        string         `json:"name"`
+		Version     string         `json:"version"`
+		Status      command.Status `json:"status"`
+		RepoVersion string         `json:"repo_version"`
+	}{
+		Name:        s.Name,
+		Version:     s.cmd.Version,
+		Status:      s.cmd.Status(),
+		RepoVersion: s.repo.CurrentHead(),
+	})
+}
+
+// Update proxies function to the its command
+func (s *Service) Update() (bool, error) {
+	return s.cmd.Update()
+}
+
+// ServiceStore represents a set of commands.
+// It has convinient methods to run and stop all
+// commands.
+type ServiceStore map[string]*Service
+
+// MarshalJSON implements json marshal interface
+func (ss ServiceStore) MarshalJSON() ([]byte, error) {
+	services := make([]*Service, len(ss))
+	for _, svc := range ss {
+		services = append(services, svc)
+	}
+
+	payload := struct {
+		Data []*Service `json:"data"`
+	}{services}
+	return json.Marshal(payload)
+}
+
+func (s *Service) logger() *log.Entry {
+	return log.WithFields(log.Fields{
+		"name":         s.Name,
+		"version":      s.cmd.Version,
+		"status":       s.cmd.Status(),
+		"repo_version": s.repo.CurrentHead(),
+	})
+}
+
+// Update search the given command in the map and runs its
+// Update function. If the command is not found, an error is
+// returned.
+func (ss *ServiceStore) Update(name string) error {
+	svc, ok := (*ss)[name]
+
+	if !ok {
+		return fmt.Errorf("services: service with name %q not found", name)
+	}
+
+	cmd := svc.cmd
+
+	svc.logger().Info("Running update")
+	cmd.SetStatus(command.StatusUpdating)
+	updated, err := cmd.Update()
+	if err != nil {
+		svc.cmd.SetStatus(command.StatusRunning)
+		return err
+	}
+
+	if !updated {
+		return nil
+	}
+
+	if err := cmd.Stop(); err != nil {
+		return err
+	}
+
+	updater := cmd.Updater
+	cmd = command.NewCommand(cmd.Log, svc.Name, cmd.Version, cmd.ExecName, cmd.ExecArgs...)
+	cmd.Updater = updater
+	(*ss)[name] = newService(svc.Name, cmd, svc.repo)
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Add builds and add the service to the list
+func (ss *ServiceStore) Add(name string, c *command.Command, r *git.Repo) {
+	s := newService(name, c, r)
+	(*ss)[s.Name] = s
+}
+
+// StartService starts a specific service inside the store.
+// If the service is not found in the list, it returns an error.
+func (ss *ServiceStore) StartService(name string) error {
+	svc, ok := (*ss)[name]
+	if !ok {
+		return fmt.Errorf("services: service %q not found for starting", name)
+	}
+
+	return svc.cmd.Start()
+}
+
+// Start starts all the commands inside the command list by
+// looping and calling each command Start function.
+func (ss *ServiceStore) Start() error {
+	for _, svc := range *ss {
+		if err := svc.cmd.Start(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// StopService stops a specific service inside the store.
+// If the service is not found in the list, it returns an error.
+func (ss *ServiceStore) StopService(name string) error {
+	svc, ok := (*ss)[name]
+	if !ok {
+		return fmt.Errorf("services: service %q not found for stopping", name)
+	}
+
+	return svc.cmd.Stop()
+}
+
+// Stop stops all the services inside the store by
+// looping and calling each service command's Stop function.
+func (ss *ServiceStore) Stop() error {
+	for _, svc := range *ss {
+		if err := svc.cmd.Stop(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/services.go
+++ b/services.go
@@ -90,18 +90,19 @@ func (ss *ServiceStore) Update(name string) error {
 	}
 
 	if !updated {
+		svc.logger().Info("No new updates")
 		return nil
 	}
 
+	svc.logger().Info("Update found, stopping")
 	if err := cmd.Stop(); err != nil {
 		return err
 	}
 
-	updater := cmd.Updater
-	cmd = command.NewCommand(cmd.Log, svc.Name, cmd.Version, cmd.ExecName, cmd.ExecArgs...)
-	cmd.Updater = updater
+	cmd = cmd.Clone()
 	(*ss)[name] = newService(svc.Name, cmd, svc.repo)
 
+	svc.logger().Info("Starting updated service")
 	if err := cmd.Start(); err != nil {
 		return err
 	}
@@ -123,6 +124,7 @@ func (ss *ServiceStore) StartService(name string) error {
 		return fmt.Errorf("services: service %q not found for starting", name)
 	}
 
+	svc.logger().Info("Starting")
 	return svc.cmd.Start()
 }
 
@@ -130,6 +132,7 @@ func (ss *ServiceStore) StartService(name string) error {
 // looping and calling each command Start function.
 func (ss *ServiceStore) Start() error {
 	for _, svc := range *ss {
+		svc.logger().Info("Starting")
 		if err := svc.cmd.Start(); err != nil {
 			return err
 		}
@@ -146,6 +149,7 @@ func (ss *ServiceStore) StopService(name string) error {
 		return fmt.Errorf("services: service %q not found for stopping", name)
 	}
 
+	svc.logger().Info("Stopping")
 	return svc.cmd.Stop()
 }
 
@@ -153,6 +157,7 @@ func (ss *ServiceStore) StopService(name string) error {
 // looping and calling each service command's Stop function.
 func (ss *ServiceStore) Stop() error {
 	for _, svc := range *ss {
+		svc.logger().Info("Stopping")
 		if err := svc.cmd.Stop(); err != nil {
 			return err
 		}

--- a/services.go
+++ b/services.go
@@ -129,16 +129,11 @@ func (ss *ServiceStore) Update(name string) error {
 func (ss *ServiceStore) Save(name string, c *command.Command, r *git.Repo) {
 	s := newService(name, c, r)
 
-	// Is this correct?
 	ss.mu.RLock()
-	list := ss.list
-	ss.mu.RUnlock()
-
-	if list == nil {
-		ss.mu.Lock()
+	if ss.list == nil {
 		ss.list = make(map[string]*Service)
-		ss.mu.Unlock()
 	}
+	ss.mu.RUnlock()
 
 	ss.mu.Lock()
 	defer ss.mu.Unlock()


### PR DESCRIPTION
We needed a way to associate `commands` with `repos`, so I introduced the concept of a Service that encapsulates both structs, and knows how to start, stop and update itself.

I also added a `ServiceStore` struct, that is a `map[string]*Service` where the key is the service's name.

I didn't like too much the idea of representing a command and a repo relation by the command's slug, so now all services have a `name` attribute, that identifies them in the store and it should be the same as its command's slug.

I also updated the realtime package, to publish the new defined payload to the healthz topic:

```json
{
  "data": [
    {
      "name": "wisebot-core",
      "version": "1a2b3c4d",
      "status": "running",
      "repo_version": "1a2b3c4d"
    }
  ]
}
```