### PR TITLE
HTTP server

### DIFF
--- a/http.go
+++ b/http.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/WiseGrowth/wisebot-operator/logger"
+	"github.com/WiseGrowth/wisebot-operator/rasp"
+	"github.com/julienschmidt/httprouter"
+)
+
+const (
+	httpPort = 5000
+)
+
+type healthResponse struct {
+	Data *ServiceStore        `json:"data"`
+	Meta *healthzMetaResponse `json:"meta"`
+}
+
+type healthzMetaResponse struct {
+	WifiStatus wifiStatus `json:"wifi_status"`
+}
+
+type wifiStatus struct {
+	IsConnected bool   `json:"is_connected"`
+	Mode        string `json:"mode"`
+}
+
+func newHealthResponse() *healthResponse {
+	isConnected, _ := rasp.IsConnected()
+
+	meta := new(healthzMetaResponse)
+	meta.WifiStatus.IsConnected = isConnected
+	meta.WifiStatus.Mode = rasp.CurrentMode().String()
+
+	return &healthResponse{
+		Data: services,
+		Meta: meta,
+	}
+}
+
+func healthzHTTPHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	log := logger.GetLogger().WithField("handler", "healthzHTTPHandler")
+	log.Info("Request received")
+
+	payload := newHealthResponse()
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		logger.GetLogger().Error(err)
+		return
+	}
+}
+
+func getNetworksHTTPHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	log := logger.GetLogger().WithField("handler", "getNetworksHTTPHandler")
+	log.Info("Request received")
+
+	networks, err := rasp.AvailableNetworks()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	payload := struct {
+		Data []*rasp.Network `json:"data"`
+	}{Data: networks}
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		logger.GetLogger().Error(err)
+	}
+}
+
+func setAPModeHTTPHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	log := logger.GetLogger().WithField("handler", "setAPModeHTTPHandler")
+	log.Info("Request received")
+
+	if err := rasp.SetAPMode(); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusCreated)
+}
+
+func updateNetworkHTTPHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	log := logger.GetLogger().WithField("handler", "updateNetworkHTTPHandler")
+	log.Info("Request received")
+
+	network := new(rasp.Network)
+	if err := json.NewDecoder(r.Body).Decode(network); err != nil {
+		log.Debug("bad payload")
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	// TODO: check if the network exists before configuring wifi
+
+	log.Debug(fmt.Sprintf("ESSID: %q Password: %q", network.ESSID, network.Password))
+	err := rasp.SetupWifi(network)
+	if err == nil {
+		log.Debug("Wifi Connected")
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	if err == rasp.ErrNoWifi {
+		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
+		if err = rasp.SetAPMode(); err != nil {
+			log.Error("Error when setting AP Mode: " + err.Error())
+		}
+		return
+	}
+
+	log.Error("Unexpected error: " + err.Error())
+	http.Error(w, err.Error(), http.StatusInternalServerError)
+}
+
+// NewHTTPServer returns an initialized server with the following routes:
+//
+// GET /healthz
+//
+// GET    /networks
+// POST   /network/ap-mode
+// PATCH  /network
+//
+func NewHTTPServer() *http.Server {
+	router := httprouter.New()
+
+	router.GET("/healthz", healthzHTTPHandler)
+
+	router.GET("/networks", getNetworksHTTPHandler)
+
+	router.POST("/network/ap-mode", setAPModeHTTPHandler)
+	router.PATCH("/network", updateNetworkHTTPHandler)
+
+	addr := fmt.Sprintf(":%d", httpPort)
+	server := &http.Server{Addr: addr, Handler: router}
+
+	return server
+}

--- a/http.go
+++ b/http.go
@@ -100,6 +100,7 @@ func updateNetworkHTTPHandler(w http.ResponseWriter, r *http.Request, _ httprout
 	err := rasp.SetupWifi(network)
 	if err == nil {
 		log.Debug("Wifi Connected")
+		// TODO: bootstrap services if it was in ap mode!
 		w.WriteHeader(http.StatusOK)
 		return
 	}

--- a/iot/iot.go
+++ b/iot/iot.go
@@ -80,6 +80,14 @@ func (c *Client) Connect() error {
 	return nil
 }
 
+// Disconnect proxies the function call to the MQTT.Client, but first checks if
+// the client is not nil.
+func (c *Client) Disconnect(quiesce uint) {
+	if c.Client != nil {
+		c.Client.Disconnect(quiesce)
+	}
+}
+
 // Subscribe is a convenience function that proxies
 // the function call to MQTT.Client.Subscribe in order
 // to subscribe to  an specific topic and MQTT.MessageHandler.

--- a/realtime.go
+++ b/realtime.go
@@ -7,18 +7,13 @@ import (
 	MQTT "github.com/eclipse/paho.mqtt.golang"
 )
 
-type healthzResponse struct {
-	Data ServiceStore `json:"data"`
-}
-
 func healthzMQTTHandler(client MQTT.Client, message MQTT.Message) {
 	topic := message.Topic()
 
 	logger := log.WithField("topic", topic)
 	logger.Info("Message received")
 
-	res := &healthzResponse{Data: services}
-	responseBytes, _ := json.Marshal(res)
+	responseBytes, _ := json.Marshal(newHealthResponse())
 
 	token := client.Publish(topic+":response", byte(1), false, responseBytes)
 	if token.Wait() && token.Error() != nil {
@@ -28,8 +23,7 @@ func healthzMQTTHandler(client MQTT.Client, message MQTT.Message) {
 
 func updateCommandMQTTHandler(client MQTT.Client, message MQTT.Message) {
 	defer func() {
-		res := &healthzResponse{Data: services}
-		responseBytes, _ := json.Marshal(res)
+		responseBytes, _ := json.Marshal(newHealthResponse())
 
 		token := client.Publish(healthzPublishableTopic+":response", byte(1), false, responseBytes)
 		if token.Wait() && token.Error() != nil {
@@ -61,8 +55,7 @@ func updateCommandMQTTHandler(client MQTT.Client, message MQTT.Message) {
 
 func stopCommandMQTTHandler(client MQTT.Client, message MQTT.Message) {
 	defer func() {
-		res := &healthzResponse{Data: services}
-		responseBytes, _ := json.Marshal(res)
+		responseBytes, _ := json.Marshal(newHealthResponse())
 
 		token := client.Publish(healthzPublishableTopic+":response", byte(1), false, responseBytes)
 		if token.Wait() && token.Error() != nil {
@@ -94,8 +87,7 @@ func stopCommandMQTTHandler(client MQTT.Client, message MQTT.Message) {
 
 func startCommandMQTTHandler(client MQTT.Client, message MQTT.Message) {
 	defer func() {
-		res := &healthzResponse{Data: services}
-		responseBytes, _ := json.Marshal(res)
+		responseBytes, _ := json.Marshal(newHealthResponse())
 
 		token := client.Publish(healthzPublishableTopic+":response", byte(1), false, responseBytes)
 		if token.Wait() && token.Error() != nil {


### PR DESCRIPTION
Add an http server with the following routes:

    GET /healthz
    GET /networks
    POST /network/ap-mode
    PATCH /network

I also added two new atribute to `Network` struct, `SignalLevel` and `Quality`. Also, we are truncating the files before writing the configuration on them.

The `main.go` now has basic offline support (only on operator boot), it only run the services and tries to connect to the MQTT client if it is not in ap mode and if it has internet connection. If is in ap mode, it does not run either the services or the mqtt client. The http server is always on, doesn't matter if has or not internet connection or if ap mode is enabled or not.