### PR TITLE
Set logger.environment="production" on compile time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 APP=operator
 BIN=$(PWD)/bin/$(APP)
-PI_IP=192.168.8.106
+PI_IP=146.155.116.82
 SENTRY_DSN=""
 
 GO ?= go
 
 pi: clean
 	@echo "[pi] Building..."
-	@GOOS=linux GOARM=7 GOARCH=arm $(GO) build -o $(BIN) -ldflags "-X main.sentryDSN=$(SENTRY_DSN)"
+	@GOOS=linux GOARM=7 GOARCH=arm $(GO) build -o $(BIN) -ldflags "-X main.sentryDSN=$(SENTRY_DSN) -X logger.environment=production"
 
 build b: clean
 	@echo "[pi] Building..."

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -5,6 +5,10 @@ import (
 	ravenSentry "github.com/evalphobia/logrus_sentry"
 )
 
+var (
+	environment string
+)
+
 // Logger is the exposed standard-ish logging interface
 type Logger interface {
 	Debug(v ...interface{})
@@ -36,7 +40,9 @@ func Init(wisebotID, sentryDSN string) error {
 	log := logrus.New()
 
 	log.Level = logrus.DebugLevel
-	// log.Formatter = &logrus.JSONFormatter{}
+	if environment == "production" {
+		log.Formatter = &logrus.JSONFormatter{}
+	}
 
 	levels := []logrus.Level{
 		logrus.PanicLevel,


### PR DESCRIPTION
When compiling for ARM architecture, set the `logger.environment` variable to
"production"