### PR TITLE
Sv feature/led

### DIFF
--- a/http.go
+++ b/http.go
@@ -90,31 +90,26 @@ func updateNetworkHTTPHandler(w http.ResponseWriter, r *http.Request, _ httprout
 	log := getLogger(r)
 	log.Debug(fmt.Sprintf("ESSID: %q Password: %q", network.ESSID, network.Password))
 
-	go func(when time.Time) {
-		if err := led.PostNetworkStatus(led.NetworkConnecting, when); err != nil {
-			log.Error(err)
-		}
-	}(time.Now())
+	if err := led.PostNetworkStatus(led.NetworkConnecting); err != nil {
+		log.Error(err)
+	}
+
 	err := rasp.SetupWifi(network)
 	if err == nil {
 		log.Debug("Wifi Connected")
 
-		go func(when time.Time) {
-			if err := led.PostNetworkStatus(led.NetworkConnected, when); err != nil {
-				log.Error(err)
-			}
-		}(time.Now())
+		if err := led.PostNetworkStatus(led.NetworkConnected); err != nil {
+			log.Error(err)
+		}
 
 		// TODO: bootstrap services if it was in ap mode!
 		w.WriteHeader(http.StatusOK)
 		return
 	}
 
-	go func(when time.Time) {
-		if err := led.PostNetworkStatus(led.NetworkError, when); err != nil {
-			log.Error(err)
-		}
-	}(time.Now())
+	if err := led.PostNetworkStatus(led.NetworkError); err != nil {
+		log.Error(err)
+	}
 
 	if err == rasp.ErrNoWifi {
 		log.Debug("No Wifi")

--- a/iot/iot.go
+++ b/iot/iot.go
@@ -156,7 +156,7 @@ func (c *Client) logger() *logrus.Entry {
 
 func (c *Client) onConnect() MQTT.OnConnectHandler {
 	return func(client MQTT.Client) {
-		c.logger().Info("Running MQTT.OnConnectHandler")
+		c.logger().Debug("Running MQTT.OnConnectHandler")
 		for topic, handler := range c.subscriptions {
 			c.Subscribe(topic, handler)
 		}

--- a/led/led.go
+++ b/led/led.go
@@ -73,7 +73,7 @@ func timeToTimestamp(t time.Time) int64 {
 }
 
 func buildURL(path string) string {
-	for path[0] == '/' && len(path) > 1 {
+	for path[0] == '/' && len(path) > 0 {
 		path = path[1:]
 	}
 

--- a/led/led.go
+++ b/led/led.go
@@ -27,11 +27,11 @@ const (
 
 func (ns NetworkStatus) String() string {
 	switch ns {
-	case Connected:
+	case NetworkConnected:
 		return "connected"
-	case Connecting:
+	case NetworkConnecting:
 		return "connecting"
-	case Error:
+	case NetworkError:
 		return "error"
 	}
 
@@ -59,6 +59,9 @@ func PostNetworkStatus(status NetworkStatus, when time.Time) error {
 	if err != nil {
 		return err
 	}
+
+	req.Header.Set("Content-Type", "application/json")
+
 	client := http.Client{}
 	_, err = client.Do(req)
 

--- a/led/led.go
+++ b/led/led.go
@@ -40,13 +40,13 @@ func (ns NetworkStatus) String() string {
 
 // PostNetworkStatus sends a request to the led service acknowledging the
 // wifi status.
-func PostNetworkStatus(status NetworkStatus, when time.Time) error {
+func PostNetworkStatus(status NetworkStatus) error {
 	payload := struct {
 		Status    string `json:"status"`
 		Timestamp int64
 	}{
 		Status:    status.String(),
-		Timestamp: timeToTimestamp(when),
+		Timestamp: timeToTimestamp(time.Now()),
 	}
 
 	bf := new(bytes.Buffer)

--- a/led/led.go
+++ b/led/led.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	urlString = "http://localhost:5001"
+	urlString = "http://localhost:5005"
 )
 
 var apiURI = mustParseURL(urlString)

--- a/led/led.go
+++ b/led/led.go
@@ -1,0 +1,88 @@
+package led
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+const (
+	urlString = "http://localhost:5001"
+)
+
+var apiURI = mustParseURL(urlString)
+
+// NetworkStatus represents the raspberry pi network status
+type NetworkStatus int
+
+// Network statuses
+const (
+	NetworkConnected NetworkStatus = iota
+	NetworkConnecting
+	NetworkError
+)
+
+func (ns NetworkStatus) String() string {
+	switch ns {
+	case Connected:
+		return "connected"
+	case Connecting:
+		return "connecting"
+	case Error:
+		return "error"
+	}
+
+	return "unknown-status"
+}
+
+// PostNetworkStatus sends a request to the led service acknowledging the
+// wifi status.
+func PostNetworkStatus(status NetworkStatus, when time.Time) error {
+	payload := struct {
+		Status    string `json:"status"`
+		Timestamp int64
+	}{
+		Status:    status.String(),
+		Timestamp: timeToTimestamp(when),
+	}
+
+	bf := new(bytes.Buffer)
+	if err := json.NewEncoder(bf).Encode(payload); err != nil {
+		return err
+	}
+
+	urlStr := buildURL("/network/" + status.String())
+	req, err := http.NewRequest("POST", urlStr, bf)
+	if err != nil {
+		return err
+	}
+	client := http.Client{}
+	_, err = client.Do(req)
+
+	return err
+}
+
+func timeToTimestamp(t time.Time) int64 {
+	return t.UnixNano() / int64(time.Millisecond)
+}
+
+func buildURL(path string) string {
+	for path[0] == '/' && len(path) > 1 {
+		path = path[1:]
+	}
+
+	return fmt.Sprintf("%s/%s", apiURI.String(), path)
+}
+
+func mustParseURL(uri string) *url.URL {
+	u, err := url.Parse(uri)
+
+	if err != nil {
+		panic(err)
+	}
+
+	return u
+}

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/signal"
 	"runtime/debug"
-	"time"
 
 	"github.com/WiseGrowth/wisebot-operator/command"
 	"github.com/WiseGrowth/wisebot-operator/git"
@@ -116,11 +115,10 @@ func main() {
 
 	log.Debug(fmt.Sprintf("Internet connection: %v", isConnected))
 	if isConnected {
-		go func(when time.Time) {
-			if err := led.PostNetworkStatus(led.NetworkConnected, when); err != nil {
-				log.Error(err)
-			}
-		}(time.Now())
+		if err := led.PostNetworkStatus(led.NetworkConnected); err != nil {
+			check(err)
+		}
+
 		log.Debug("Bootstraping and starting services")
 		const update = true
 		check(bootstrapServices(update))

--- a/rasp/wifi.go
+++ b/rasp/wifi.go
@@ -202,7 +202,7 @@ func IsConnected() (bool, error) {
 		return true, nil
 	}
 
-	ping := exec.Command("ping", "-t", "20", "-w", "1", "8.8.8.8")
+	ping := exec.Command("ping", "-t", "20", "-c", "1", "8.8.8.8")
 
 	if err := ping.Run(); err != nil {
 		// Ignore exit errors


### PR DESCRIPTION
There is a led service that runs next to this app that needs to be notified about the internet configuration operations like, knowing when is trying to connect to the router/modem (`connecting` state) and whether if the connection is successful (`connected` state) or not (`error` state).

I implemented a led package that has a convenient function to notify the led service the network configuration status. I'm not sure if we should send these notifications in background since is one of the most important visual feedback that the user has (changing wisebot's led color), and the execution time should be negligible.