### PR TITLE
Add elasticsearch logrus hook

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -3,10 +3,17 @@ package logger
 import (
 	"github.com/Sirupsen/logrus"
 	ravenSentry "github.com/evalphobia/logrus_sentry"
+	elastic "gopkg.in/olivere/elastic.v5"
+	elogrus "gopkg.in/sohlich/elogrus.v2"
 )
 
 var (
 	environment string
+)
+
+const (
+	elasticsearchURL   = "https://search-wisegrowth-jl3kj4kwv225mzcssitu47xlqe.us-west-2.es.amazonaws.com"
+	elasticsearchIndex = "wisebot-operator"
 )
 
 // Logger is the exposed standard-ish logging interface
@@ -26,7 +33,7 @@ var (
 )
 
 // setLogger sets the package level logger
-func setLogger(l *logrus.Logger) {
+func setLogger(l *logrus.Entry) {
 	log = l
 }
 
@@ -42,6 +49,20 @@ func Init(wisebotID, sentryDSN string) error {
 	log.Level = logrus.DebugLevel
 	if environment == "production" {
 		log.Formatter = &logrus.JSONFormatter{}
+		client, err := elastic.NewClient(
+			elastic.SetURL(elasticsearchURL),
+			elastic.SetScheme("https"),
+			elastic.SetSniff(false),
+		)
+		if err != nil {
+			log.Panic(err)
+		}
+		ehook, err := elogrus.NewElasticHook(client, "localhost", logrus.DebugLevel, elasticsearchIndex)
+		if err != nil {
+			return err
+		}
+
+		log.Hooks.Add(ehook)
 	}
 
 	levels := []logrus.Level{
@@ -50,16 +71,16 @@ func Init(wisebotID, sentryDSN string) error {
 		logrus.ErrorLevel,
 	}
 
-	hook, err := ravenSentry.NewAsyncWithTagsSentryHook(sentryDSN, map[string]string{"wisebot-id": wisebotID}, levels)
+	shook, err := ravenSentry.NewAsyncWithTagsSentryHook(sentryDSN, map[string]string{"wisebot-id": wisebotID}, levels)
 	if err != nil {
 		return err
 	}
 
-	hook.StacktraceConfiguration.Enable = true
+	shook.StacktraceConfiguration.Enable = true
 
-	log.Hooks.Add(hook)
-	log = log.WithField("wisebot-id", wisebotID).Logger
-	setLogger(log)
+	log.Hooks.Add(shook)
+
+	setLogger(log.WithField("wisebot-id", wisebotID))
 
 	return nil
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -8,11 +8,11 @@ import (
 )
 
 var (
-	environment string
+	environment      string
+	elasticsearchURL string
 )
 
 const (
-	elasticsearchURL   = "https://search-wisegrowth-jl3kj4kwv225mzcssitu47xlqe.us-west-2.es.amazonaws.com"
 	elasticsearchIndex = "wisebot-operator"
 )
 


### PR DESCRIPTION
This PR sends all logs to AWS elasticsearch.

We were not logging the wisebot-id value, because we were using a logrus Logger instead of a logrus Entry.
The logrus.Entry struct holds the keys and values, so in order to print them, we must use it instead of the plain logrus.Logger.