### PR TITLE
Prepare for alpha

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin/
 *.js
 config.json
 *.sh
+*.log

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 APP=operator
 BIN=$(PWD)/bin/$(APP)
-PI_IP=192.168.8.103
+PI_IP=wisebot.pi
 
 GO ?= go
 
@@ -26,6 +26,5 @@ upload:
 	@echo "[upload] Done"
 
 deploy: pi upload
-	@echo "[deploy] Done"
 
 .PHONY: pi build b clean upload deploy run

--- a/command/command.go
+++ b/command/command.go
@@ -29,9 +29,6 @@ type Command struct {
 
 	Version string
 
-	// Maybe this will help us debugging when a command fails?
-	// stderr *bytes.Buffer
-
 	status   Status
 	execName string
 	execArgs []string

--- a/command/command.go
+++ b/command/command.go
@@ -1,10 +1,8 @@
 package command
 
 import (
-	"bufio"
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -27,7 +25,6 @@ const (
 // Command represents a os level command, which can also receive a logger file
 // in order to dump the output to it.
 type Command struct {
-	Log io.WriteCloser
 	Cmd *exec.Cmd
 
 	Version string
@@ -44,7 +41,7 @@ type Command struct {
 // and returns it. This is handy if you need to restart the process, first
 // you stop it, then clone it, then you start the new cloned process.
 func (c *Command) Clone() *Command {
-	cmd := NewCommand(c.Log, c.Version, c.execName, c.execArgs...)
+	cmd := NewCommand(c.Version, c.execName, c.execArgs...)
 	return cmd
 }
 
@@ -110,22 +107,8 @@ func (c *Command) Status() Status {
 	return c.status
 }
 
-// CloseLog safely close the command's logger. If the logger is just os.Stdout,
-// it does not close it.
-func (c *Command) CloseLog() error {
-	if c.Log == nil || c.Log == os.Stdout {
-		return nil
-	}
-
-	return c.Log.Close()
-}
-
 // Stop stops the command and closes the log file if exists.
 func (c *Command) Stop() error {
-	if c.Log != nil {
-		defer c.CloseLog()
-	}
-
 	if c.status == StatusStopped {
 		return fmt.Errorf("commands: command %q is already stopped", c.Slug())
 	}
@@ -159,34 +142,7 @@ func (c *Command) Wait() error {
 // Start starts the process and pipes the command's output to the log file.
 // If at any point there is an error it also closes the file if exists.
 func (c *Command) Start() error {
-	if c.Log == os.Stdout || c.Log == nil {
-		c.Cmd.Stdout = c.Log
-	} else {
-		out, err := c.Cmd.StdoutPipe()
-		if err != nil {
-			c.CloseLog()
-			return err
-		}
-
-		go func() {
-			for {
-				r := bufio.NewReader(out)
-				l, _, err := r.ReadLine()
-				if err != nil {
-					if err != io.EOF {
-						c.CloseLog()
-						panic(err)
-					}
-				}
-
-				c.Log.Write(l)
-				c.Log.Write([]byte("\n"))
-			}
-		}()
-	}
-
 	if err := c.Cmd.Start(); err != nil {
-		c.CloseLog()
 		return err
 	}
 
@@ -201,9 +157,8 @@ func (c *Command) Success() bool {
 }
 
 // NewCommand returns an initalized command pointer.
-func NewCommand(log io.WriteCloser, version, name string, args ...string) *Command {
+func NewCommand(version, name string, args ...string) *Command {
 	cmd := &Command{
-		Log:     log,
 		Cmd:     exec.Command(name, args...),
 		Version: version,
 

--- a/config.go
+++ b/config.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+
+	homedir "github.com/mitchellh/go-homedir"
 )
 
 type config struct {
@@ -22,7 +24,12 @@ var (
 )
 
 func loadConfig(path string) (*config, error) {
-	fileBytes, err := ioutil.ReadFile(path)
+	expandedPath, err := homedir.Expand(path)
+	if err != nil {
+		return nil, err
+	}
+
+	fileBytes, err := ioutil.ReadFile(expandedPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, errNoConfigFile

--- a/config.go
+++ b/config.go
@@ -11,9 +11,10 @@ import (
 type config struct {
 	WisebotID    string `json:"id"`
 	Certificates struct {
-		PrivateKey  string `json:"privateKey"`
+		PrivateKey  string `json:"private_key"`
 		Certificate string `json:"certificate"`
 	} `json:"keys"`
+	AWSIOTHost string `json:"aws_iot_host"`
 }
 
 var (

--- a/git/repo.go
+++ b/git/repo.go
@@ -53,7 +53,7 @@ func (r *Repo) MarshalJSON() ([]byte, error) {
 type PostReceiveHook func(*Repo) error
 
 const (
-	upstream = "origin/master"
+	upstream = "origin/development"
 )
 
 // Update runs a git fetch to the `origin` remote, if the origin/master has a

--- a/git/repo.go
+++ b/git/repo.go
@@ -100,13 +100,6 @@ func (r *Repo) Update() (updatedHeadSHA string, err error) {
 		return "", err
 	}
 
-	cleanCmd := exec.Command("git", "clean", "-f", "-d", "-X")
-	cleanCmd.Dir = r.Path
-
-	log.Info("Cleaning")
-	if err := cleanCmd.Run(); err != nil {
-		return "", err
-	}
 	log.Info("Update finished")
 	if err := r.runPostReceiveHooks(); err != nil {
 		return "", err
@@ -210,7 +203,7 @@ func sanitizeOutput(b []byte) string {
 // NpmInstallHook is a PostReceiveHook preset that runs a
 // `npm install --production` command.
 func NpmInstallHook(r *Repo) error {
-	npmInstall := exec.Command("npm", "install", "--production")
+	npmInstall := exec.Command("sudo", "npm", "install", "--production")
 	npmInstall.Dir = r.Path
 
 	r.logger().Info("Running npm install")
@@ -219,7 +212,7 @@ func NpmInstallHook(r *Repo) error {
 
 // NpmPruneHook is a PostReceiveHook preset that runs a `npm prune` command.
 func NpmPruneHook(r *Repo) error {
-	prune := exec.Command("npm", "prune")
+	prune := exec.Command("sudo", "npm", "prune")
 	prune.Dir = r.Path
 
 	r.logger().Info("Running npm prune")

--- a/git/repo.go
+++ b/git/repo.go
@@ -7,10 +7,15 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"runtime"
 
 	"github.com/Sirupsen/logrus"
 
 	"github.com/WiseGrowth/wisebot-operator/logger"
+)
+
+const (
+	onOSX = (runtime.GOOS == "darwin")
 )
 
 // Repo represents a git repo, it contains its path and remote. This struct has
@@ -204,6 +209,9 @@ func sanitizeOutput(b []byte) string {
 // `npm install --production` command.
 func NpmInstallHook(r *Repo) error {
 	npmInstall := exec.Command("sudo", "npm", "install", "--production")
+	if onOSX {
+		npmInstall = exec.Command("npm", "install", "--production")
+	}
 	npmInstall.Dir = r.Path
 
 	r.logger().Info("Running npm install")
@@ -213,6 +221,9 @@ func NpmInstallHook(r *Repo) error {
 // NpmPruneHook is a PostReceiveHook preset that runs a `npm prune` command.
 func NpmPruneHook(r *Repo) error {
 	prune := exec.Command("sudo", "npm", "prune")
+	if onOSX {
+		prune = exec.Command("npm", "prune")
+	}
 	prune.Dir = r.Path
 
 	r.logger().Info("Running npm prune")

--- a/iot/iot.go
+++ b/iot/iot.go
@@ -137,15 +137,13 @@ func NewClient(configs ...Config) (*Client, error) {
 		config(client)
 	}
 
-	client.clientOptions = &MQTT.ClientOptions{
-		ClientID:             client.id,
-		CleanSession:         true,
-		AutoReconnect:        true,
-		MaxReconnectInterval: 1 * time.Second,
-		KeepAlive:            30 * time.Second,
-		TLSConfig:            tls.Config{Certificates: []tls.Certificate{client.certificate}},
-		OnConnect:            client.onConnect(),
-	}
+	copts := MQTT.NewClientOptions()
+	copts.SetClientID(client.id)
+	copts.SetMaxReconnectInterval(1 * time.Second)
+	copts.SetOnConnectHandler(client.onConnect())
+	copts.SetTLSConfig(&tls.Config{Certificates: []tls.Certificate{client.certificate}})
+
+	client.clientOptions = copts
 
 	client.clientOptions.AddBroker(client.brokerURL(secureProtocol))
 

--- a/iot/iot.go
+++ b/iot/iot.go
@@ -29,8 +29,14 @@ const (
 func SetDebug(debug bool) {
 	if debug {
 		MQTT.DEBUG = stdlog.New(os.Stdout, "[MQTT-DEBUG] ", 0)
+		MQTT.CRITICAL = stdlog.New(os.Stdout, "[MQTT-CRITICAL] ", 0)
+		MQTT.WARN = stdlog.New(os.Stdout, "[MQTT-WARN] ", 0)
+		MQTT.ERROR = stdlog.New(os.Stdout, "[MQTT-ERROR] ", 0)
 	} else {
 		MQTT.DEBUG = stdlog.New(ioutil.Discard, "", 0)
+		MQTT.CRITICAL = stdlog.New(ioutil.Discard, "", 0)
+		MQTT.WARN = stdlog.New(ioutil.Discard, "", 0)
+		MQTT.ERROR = stdlog.New(ioutil.Discard, "", 0)
 	}
 }
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -35,8 +35,9 @@ func GetLogger() Logger {
 }
 
 // Init initialize the global module logger
-func Init(wisebotID, sentryDSN string) error {
+func Init(out io.Writer, wisebotID, sentryDSN string) error {
 	log := logrus.New()
+	log.Out = out
 
 	log.Level = logrus.DebugLevel
 	if environment == "production" {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,33 +1,16 @@
 package logger
 
 import (
-	"strings"
+	"io"
 
 	"github.com/Sirupsen/logrus"
 	ravenSentry "github.com/evalphobia/logrus_sentry"
-	elastic "gopkg.in/olivere/elastic.v5"
-	elogrus "gopkg.in/sohlich/elogrus.v2"
 )
 
 var (
-	environment              string
-	elasticsearchURL         string
-	elasticsearchURLProtocol string
-
-	log Logger = logrus.New()
+	environment string
+	log         Logger = logrus.New()
 )
-
-const (
-	elasticsearchIndex = "wisebot-operator"
-)
-
-func init() {
-	if strings.HasPrefix(elasticsearchURL, "https://") {
-		elasticsearchURLProtocol = "https"
-	} else {
-		elasticsearchURLProtocol = "http"
-	}
-}
 
 // Logger is the exposed standard-ish logging interface
 type Logger interface {
@@ -58,23 +41,6 @@ func Init(wisebotID, sentryDSN string) error {
 	log.Level = logrus.DebugLevel
 	if environment == "production" {
 		log.Formatter = &logrus.JSONFormatter{}
-	}
-
-	if len(elasticsearchURL) > 0 {
-		client, err := elastic.NewClient(
-			elastic.SetURL(elasticsearchURL),
-			elastic.SetScheme(elasticsearchURLProtocol),
-			elastic.SetSniff(false),
-		)
-		if err != nil {
-			log.Panic(err)
-		}
-		hook, err := elogrus.NewElasticHook(client, "localhost", logrus.DebugLevel, elasticsearchIndex)
-		if err != nil {
-			return err
-		}
-
-		log.Hooks.Add(hook)
 	}
 
 	if len(sentryDSN) > 0 {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -25,7 +25,7 @@ type Logger interface {
 }
 
 // setLogger sets the package level logger
-func setLogger(l *logrus.Entry) {
+func setLogger(l *logrus.Logger) {
 	log = l
 }
 
@@ -61,7 +61,7 @@ func Init(out io.Writer, wisebotID, sentryDSN string) error {
 		log.Hooks.Add(hook)
 	}
 
-	setLogger(log.WithField("wisebot-id", wisebotID))
+	setLogger(log)
 
 	return nil
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -51,7 +51,7 @@ func Init(out io.Writer, wisebotID, sentryDSN string) error {
 			logrus.ErrorLevel,
 		}
 
-		hook, err := ravenSentry.NewAsyncWithTagsSentryHook(sentryDSN, map[string]string{"wisebot-id": wisebotID}, levels)
+		hook, err := ravenSentry.NewAsyncWithTagsSentryHook(sentryDSN, map[string]string{"wisebot_id": wisebotID}, levels)
 		if err != nil {
 			return err
 		}

--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ func init() {
 
 	healthzPublishableTopic = fmt.Sprintf("/operator/%s/healthz", wisebotConfig.WisebotID)
 
-	wisebotLogger, err := newFile("wisebot.log")
+	wisebotLogger, err := newFile(wisebotLogPath)
 	check(err)
 	check(logger.Init(wisebotLogger, wisebotConfig.WisebotID, sentryDSN))
 

--- a/main.go
+++ b/main.go
@@ -24,9 +24,9 @@ var (
 )
 
 const (
-	wisebotServiceName    = "wisebot-test"
-	wisebotCoreRepoPath   = "~/wisebot-test"
-	wisebotCoreRepoRemote = "git@github.com:wisegrowth/test.git"
+	wisebotCoreServiceName = "wisebot-core"
+	wisebotCoreRepoPath    = "~/wisebot-core"
+	wisebotCoreRepoRemote  = "git@github.com:wisegrowth/wisebot-core.git"
 
 	bleServiceName = "wisebot-ble"
 	bleRepoPath    = "~/wisebot-ble"
@@ -101,7 +101,7 @@ func main() {
 	)
 
 	// ----- Append services to global store
-	services.Save(wisebotServiceName, wisebotCoreCommand, wisebotCoreRepo)
+	services.Save(wisebotCoreServiceName, wisebotCoreCommand, wisebotCoreRepo)
 
 	httpServer = NewHTTPServer()
 	log.Info("Running server on: " + httpServer.Addr)

--- a/main.go
+++ b/main.go
@@ -76,7 +76,7 @@ func init() {
 	check(err)
 
 	mqttClient, err = iot.NewClient(
-		iot.SetHost(iotHost),
+		iot.SetHost(wisebotConfig.AWSIOTHost),
 		iot.SetCertificate(*cert),
 	)
 	check(err)

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"syscall"
 
 	"github.com/WiseGrowth/wisebot-operator/command"
 	"github.com/WiseGrowth/wisebot-operator/git"
@@ -150,7 +151,7 @@ func bootstrapServices(update bool) error {
 
 func listenInterrupt(quit chan struct{}) {
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-c
 

--- a/main.go
+++ b/main.go
@@ -66,7 +66,9 @@ func init() {
 
 	healthzPublishableTopic = fmt.Sprintf("/operator/%s/healthz", wisebotConfig.WisebotID)
 
-	check(logger.Init(wisebotConfig.WisebotID, sentryDSN))
+	wisebotLogger, err := newFile("wisebot.log")
+	check(err)
+	check(logger.Init(wisebotLogger, wisebotConfig.WisebotID, sentryDSN))
 
 	// ----- Initialize MQTT client
 	cert, err := wisebotConfig.getTLSCertificate()

--- a/main.go
+++ b/main.go
@@ -94,7 +94,6 @@ func main() {
 
 	// ----- Initialize commands
 	wisebotCoreCommand := command.NewCommand(
-		nil,
 		wisebotCoreRepo.CurrentHead(),
 		"node",
 		wisebotCoreRepoExpandedPath+"/build/app/index.js",

--- a/main.go
+++ b/main.go
@@ -37,7 +37,6 @@ const (
 )
 
 var (
-	wisebotConfigExpandedPath   string
 	wisebotCoreRepoExpandedPath string
 	bleRepoExpandedPath         string
 
@@ -54,14 +53,11 @@ func init() {
 	var err error
 	services = new(ServiceStore)
 
-	wisebotConfigExpandedPath, err = homedir.Expand(wisebotConfigPath)
-	check(err)
-
 	wisebotCoreRepoExpandedPath, err = homedir.Expand(wisebotCoreRepoPath)
 	check(err)
 
 	// ----- Load wisebot config
-	wisebotConfig, err = loadConfig(wisebotConfigExpandedPath)
+	wisebotConfig, err = loadConfig(wisebotConfigPath)
 	check(err)
 
 	healthzPublishableTopic = fmt.Sprintf("/operator/%s/healthz", wisebotConfig.WisebotID)

--- a/main.go
+++ b/main.go
@@ -199,11 +199,14 @@ func bootstrapMQTTClient() error {
 
 func check(err error) {
 	if err != nil {
+		debug.PrintStack()
 		log := logger.GetLogger()
-		if e, ok := (err).(*exec.ExitError); ok {
+
+		switch (err).(type) {
+		case *exec.ExitError:
+			e, _ := (err).(*exec.ExitError)
 			log.WithField("stderr", string(e.Stderr)).Fatal(err)
-		} else {
-			debug.PrintStack()
+		default:
 			log.Fatal(err)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"os/exec"
 	"os/signal"
 	"runtime/debug"
 
@@ -200,7 +201,12 @@ func bootstrapMQTTClient() error {
 
 func check(err error) {
 	if err != nil {
-		debug.PrintStack()
-		logger.GetLogger().Fatal(err)
+		log := logger.GetLogger()
+		if e, ok := (err).(*exec.ExitError); ok {
+			log.WithField("stderr", string(e.Stderr)).Fatal(err)
+		} else {
+			debug.PrintStack()
+			log.Fatal(err)
+		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"net/http"
 	"os"
@@ -200,7 +201,8 @@ func check(err error) {
 		switch (err).(type) {
 		case *exec.ExitError:
 			e, _ := (err).(*exec.ExitError)
-			log.WithField("stderr", string(e.Stderr)).Fatal(err)
+			stderr := bytes.TrimSpace(e.Stderr)
+			log.WithField("stderr", string(stderr)).Fatal(err)
 		default:
 			log.Fatal(err)
 		}

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ const (
 	bleRepoRemote  = "git@github.com:wisegrowth/wisebot-ble.git"
 
 	wisebotConfigPath = "~/.config/wisebot/config.json"
+	wisebotLogPath    = "~/.wisebot/logs/operator.log"
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -32,9 +32,7 @@ const (
 	bleRepoPath    = "~/wisebot-ble"
 	bleRepoRemote  = "git@github.com:wisegrowth/wisebot-ble.git"
 
-	wisebotConfigPath = "~/.config/wisebot-operator/config.json"
-
-	iotHost = "a55lp0huv9vtb.iot.us-west-2.amazonaws.com"
+	wisebotConfigPath = "~/.config/wisebot/config.json"
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -78,6 +78,7 @@ func init() {
 	mqttClient, err = iot.NewClient(
 		iot.SetHost(wisebotConfig.AWSIOTHost),
 		iot.SetCertificate(*cert),
+		iot.SetClientID("op-"+wisebotConfig.WisebotID),
 	)
 	check(err)
 }

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
-	"runtime/debug"
 
 	"github.com/WiseGrowth/wisebot-operator/command"
 	"github.com/WiseGrowth/wisebot-operator/git"
@@ -196,7 +195,6 @@ func bootstrapMQTTClient() error {
 
 func check(err error) {
 	if err != nil {
-		debug.PrintStack()
 		log := logger.GetLogger()
 
 		switch (err).(type) {

--- a/rasp/wifi.go
+++ b/rasp/wifi.go
@@ -198,10 +198,6 @@ func configureWPASupplicantWithNetwork(n *Network) error {
 // IsConnected executes a ping command in order to check wether the device is
 // connected to the network.
 func IsConnected() (bool, error) {
-	if onOSX {
-		return true, nil
-	}
-
 	ping := exec.Command("ping", "-t", "20", "-c", "1", "8.8.8.8")
 
 	if err := ping.Run(); err != nil {

--- a/realtime.go
+++ b/realtime.go
@@ -3,15 +3,15 @@ package main
 import (
 	"encoding/json"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/WiseGrowth/wisebot-operator/logger"
 	MQTT "github.com/eclipse/paho.mqtt.golang"
 )
 
 func healthzMQTTHandler(client MQTT.Client, message MQTT.Message) {
 	topic := message.Topic()
 
-	logger := log.WithField("topic", topic)
-	logger.Info("Message received")
+	log := logger.GetLogger().WithField("topic", topic)
+	log.Info("Message received")
 
 	responseBytes, _ := json.Marshal(newHealthResponse())
 
@@ -22,6 +22,9 @@ func healthzMQTTHandler(client MQTT.Client, message MQTT.Message) {
 }
 
 func updateCommandMQTTHandler(client MQTT.Client, message MQTT.Message) {
+	topic := message.Topic()
+	log := logger.GetLogger().WithField("topic", topic)
+
 	defer func() {
 		responseBytes, _ := json.Marshal(newHealthResponse())
 
@@ -31,10 +34,7 @@ func updateCommandMQTTHandler(client MQTT.Client, message MQTT.Message) {
 		}
 	}()
 
-	topic := message.Topic()
-
-	logger := log.WithField("topic", topic)
-	logger.Info("Message received")
+	log.Info("Message received")
 
 	payload := struct {
 		Process struct {
@@ -54,6 +54,9 @@ func updateCommandMQTTHandler(client MQTT.Client, message MQTT.Message) {
 }
 
 func stopCommandMQTTHandler(client MQTT.Client, message MQTT.Message) {
+	topic := message.Topic()
+	log := logger.GetLogger().WithField("topic", topic)
+
 	defer func() {
 		responseBytes, _ := json.Marshal(newHealthResponse())
 
@@ -63,10 +66,7 @@ func stopCommandMQTTHandler(client MQTT.Client, message MQTT.Message) {
 		}
 	}()
 
-	topic := message.Topic()
-
-	logger := log.WithField("topic", topic)
-	logger.Info("Message received")
+	log.Info("Message received")
 
 	payload := struct {
 		Process struct {
@@ -86,6 +86,9 @@ func stopCommandMQTTHandler(client MQTT.Client, message MQTT.Message) {
 }
 
 func startCommandMQTTHandler(client MQTT.Client, message MQTT.Message) {
+	topic := message.Topic()
+	log := logger.GetLogger().WithField("topic", topic)
+
 	defer func() {
 		responseBytes, _ := json.Marshal(newHealthResponse())
 
@@ -94,11 +97,7 @@ func startCommandMQTTHandler(client MQTT.Client, message MQTT.Message) {
 			log.Error(token.Error())
 		}
 	}()
-
-	topic := message.Topic()
-
-	logger := log.WithField("topic", topic)
-	logger.Info("Message received")
+	log.Info("Message received")
 
 	payload := struct {
 		Process struct {

--- a/utils.go
+++ b/utils.go
@@ -1,9 +1,17 @@
 package main
 
-import "os"
+import (
+	"os"
+
+	homedir "github.com/mitchellh/go-homedir"
+)
 
 func newFile(name string) (*os.File, error) {
-	file, err := os.OpenFile(name, os.O_APPEND|os.O_WRONLY, 0600)
+	expanded, err := homedir.Expand(name)
+	if err != nil {
+		return nil, err
+	}
+	file, err := os.OpenFile(expanded, os.O_APPEND|os.O_WRONLY, 0666)
 	if err != nil {
 		if os.IsNotExist(err) {
 			file, err = os.Create(name)

--- a/utils.go
+++ b/utils.go
@@ -11,7 +11,7 @@ func newFile(name string) (*os.File, error) {
 	if err != nil {
 		return nil, err
 	}
-	file, err := os.OpenFile(expanded, os.O_APPEND|os.O_WRONLY, 0666)
+	file, err := os.OpenFile(expanded, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0744)
 	if err != nil {
 		if os.IsNotExist(err) {
 			file, err = os.Create(name)


### PR DESCRIPTION
I did a bunch of modifications in order to make it work on the raspberry. Now is stable and has the following additions:

- The operator now is started by [systemd](https://www.freedesktop.org/wiki/Software/systemd/) on the raspberry and gracefully shut downs itself when receiving either an `SIGINT` or `SIGTERM` signal.
- Removed unnecessary wisebot id from logger.
- Uses the package `logger` within all files.
- Write all logs to `~/.wisebot/logs/operator.log`
- Do not manage child process (`command.Command`) output, like Stdout and Stderr, anymore. Each subprocess manages its own output and sends it to a log file.
- Fix `git` presets bugs on `npm install` and `npm prune` functions.
- Remove sensitive data like URLs and tokens from code. We assign some values on compilation time and gets the other ones from a config file.
- Add `stderr` attribute when logging a `exec.ExitError` error.
- Standardize logger keys by only using snake_case.
- Remove logrus' elasticsearch hook, since now the raspberry uses [filebeat](https://www.elastic.co/products/beats/filebeat) to collect and send the logs to [elasticsearch](https://www.elastic.co/).