### PR TITLE
Add mutex to guard process manager functions

### DIFF
--- a/process_manager.go
+++ b/process_manager.go
@@ -20,7 +20,7 @@ type ProcessManager struct {
 // managed by the operator. This function must be called after checking that
 // there is internet connection, otherwise, messaging client and subprocesses
 // are going to fail.
-// Both, subprocesses and messaging client knows how to reconnect where they
+// Both, subprocesses and messaging client knows how to reconnect when they
 // lose connection, but they must be started while being online.
 func (pm *ProcessManager) KickOff() error {
 	pm.Lock()

--- a/process_manager.go
+++ b/process_manager.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"sync"
+
 	"github.com/WiseGrowth/wisebot-operator/iot"
 	"github.com/WiseGrowth/wisebot-operator/led"
 	"github.com/WiseGrowth/wisebot-operator/logger"
@@ -8,6 +10,7 @@ import (
 
 // ProcessManager is in charge of starting and stoping the processes.
 type ProcessManager struct {
+	sync.Mutex
 	Services   *ServiceStore
 	MQTTClient *iot.Client
 	started    bool
@@ -20,6 +23,9 @@ type ProcessManager struct {
 // Both, subprocesses and messaging client knows how to reconnect where they
 // lose connection, but they must be started while being online.
 func (pm *ProcessManager) KickOff() error {
+	pm.Lock()
+	defer pm.Unlock()
+
 	log := logger.GetLogger()
 	log.Debug("Bootstraping and starting services")
 
@@ -48,6 +54,9 @@ func (pm *ProcessManager) KickOff() error {
 
 // Stop stops `pm.ServiceStore` services and disconnects the MQTT Client.
 func (pm *ProcessManager) Stop() {
+	pm.Lock()
+	defer pm.Unlock()
+
 	log := logger.GetLogger()
 	pm.MQTTClient.Disconnect(250)
 	log.Info("[MQTT] Disconnected")


### PR DESCRIPTION
Both, KickOff and Stop functions from the process manager can be executed one at a time, so I added a mutex to guard them.