### PR TITLE
Prepare for almost beta

### DIFF
--- a/http.go
+++ b/http.go
@@ -64,6 +64,7 @@ func healthzHTTPHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Par
 	payload := newHealthResponse()
 	if err := json.NewEncoder(w).Encode(payload); err != nil {
 		getLogger(r).Error(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 }

--- a/http.go
+++ b/http.go
@@ -61,6 +61,7 @@ func getLogger(r *http.Request) logger.Logger {
 }
 
 func healthzHTTPHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	w.Header().Set("Content-Type", "application/json")
 	payload := newHealthResponse()
 	if err := json.NewEncoder(w).Encode(payload); err != nil {
 		getLogger(r).Error(err)
@@ -70,6 +71,7 @@ func healthzHTTPHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Par
 }
 
 func getNetworksHTTPHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	w.Header().Set("Content-Type", "application/json")
 	networks, err := rasp.AvailableNetworks()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/iot/iot.go
+++ b/iot/iot.go
@@ -86,6 +86,16 @@ func (c *Client) Connect() error {
 	return nil
 }
 
+// IsConnected proxies the function call to the MQTT.Client, but first checks if
+// the client is not nil.
+func (c *Client) IsConnected() bool {
+	if c.Client == nil {
+		return false
+	}
+
+	return c.Client.IsConnected()
+}
+
 // Disconnect proxies the function call to the MQTT.Client, but first checks if
 // the client is not nil.
 func (c *Client) Disconnect(quiesce uint) {

--- a/process_manager.go
+++ b/process_manager.go
@@ -67,11 +67,10 @@ func (pm *ProcessManager) bootstrapServices(update bool) error {
 	}
 
 	log.Debug("Starting commands")
-	// TODO: uncomment the following lines
-	// if err := pm.Services.Start(); err != nil {
-	// 	pm.Services.Stop()
-	// 	return err
-	// }
+	if err := pm.Services.Start(); err != nil {
+		pm.Services.Stop()
+		return err
+	}
 
 	return nil
 }

--- a/services.go
+++ b/services.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"sync"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 
 	"github.com/WiseGrowth/wisebot-operator/command"
 	"github.com/WiseGrowth/wisebot-operator/git"
@@ -77,8 +77,8 @@ func (ss *ServiceStore) MarshalJSON() ([]byte, error) {
 	return json.Marshal(svcs)
 }
 
-func (s *Service) logger() *log.Entry {
-	return logger.GetLogger().WithFields(log.Fields{
+func (s *Service) logger() *logrus.Entry {
+	return logger.GetLogger().WithFields(logrus.Fields{
 		"name":            s.Name,
 		"command_version": s.cmd.Version,
 		"status":          s.cmd.Status(),


### PR DESCRIPTION
- Run services when starting the operator. This was disabled just for debugging purposes.
- Fix async runtime panic when calling `isConnected` in mqtt client when booting the operator.
- Respond with an http 500 internal server error when healthz fails.