### PR TITLE
Observe and notify service exit error if exists

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -27,7 +27,8 @@ const (
 // Command represents a os level command, which can also receive a logger file
 // in order to dump the output to it.
 type Command struct {
-	Cmd *exec.Cmd
+	Cmd    *exec.Cmd
+	Finish chan<- error // sends command exit error provided by `exec.Cmd.Wait`
 
 	Version string
 
@@ -44,6 +45,7 @@ type Command struct {
 func (c *Command) Clone() *Command {
 	cmd := NewCommand(c.execName, c.execArgs...)
 	cmd.Version = c.Version
+	cmd.Finish = c.Finish
 	return cmd
 }
 
@@ -164,6 +166,7 @@ func (c *Command) Start() error {
 			c.status = StatusError
 		}
 		c.exitError <- err
+		c.Finish <- err
 	}()
 
 	c.status = StatusRunning

--- a/led/led.go
+++ b/led/led.go
@@ -38,6 +38,38 @@ func (ns NetworkStatus) String() string {
 	return "unknown-status"
 }
 
+// PostServiceExitError sends a request to the led service acknowledging that
+// a service exited with error.
+func PostServiceExitError(name string, when time.Time) error {
+	payload := struct {
+		Name      string `json:"name"`
+		Status    string `json:"status"`
+		Timestamp int64
+	}{
+		Name:      name,
+		Status:    "error",
+		Timestamp: timeToTimestamp(when),
+	}
+
+	bf := new(bytes.Buffer)
+	if err := json.NewEncoder(bf).Encode(payload); err != nil {
+		return err
+	}
+
+	urlStr := buildURL("/service")
+	req, err := http.NewRequest("POST", urlStr, bf)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	client := http.Client{}
+	_, err = client.Do(req)
+
+	return err
+}
+
 // PostNetworkStatus sends a request to the led service acknowledging the
 // wifi status.
 func PostNetworkStatus(status NetworkStatus, when time.Time) error {


### PR DESCRIPTION
If a service exited with an error, led service will be notified.

Notification is made by sending a POST request to `localhost:5005/service` with the following payload:

```json
{ "name": "core", "status": "error", "timestamp": 1234 }
```