### PR TITLE
Ca feature/self update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,32 @@
 APP=operator
-BIN=$(PWD)/bin/$(APP)
+UPLOADER_APP=uploader
+BIN_FOLDER=$(PWD)/bin
+BIN=$(BIN_FOLDER)/$(APP)
+UPLOADER_BIN=$(BIN_FOLDER)/$(UPLOADER_APP)
+
+VERSION=1.1.99
 PI_IP=192.168.8.101
 GIT_SHA=`git rev-parse --short HEAD`
+BASE_URL=https://s3.us-west-2.amazonaws.com/wisebot-operator-releases/operator-
+REGION=us-west-2
+BUCKET_RELEASES=wisebot-operator-releases
 
+OPENSSL ?= openssl
 GO ?= go
 
 pi: clean
 	@echo "[pi] Building..."
-	@GOOS=linux GOARM=7 GOARCH=arm $(GO) build -o $(BIN)\
-		-ldflags "-X main.operatorVersion=$(GIT_SHA) -X github.com/WiseGrowth/go-wisebot/logger.environment=production"
+	@GOOS=linux GOARM=7 GOARCH=arm $(GO) build -o $(BIN)-$(VERSION)\
+		-ldflags "-X main.operatorVersion=$(GIT_SHA) -X github.com/WiseGrowth/go-wisebot/logger.environment=production -X main.version=$(VERSION) -X main.baseURL=$(BASE_URL)"
 
 build b: clean
 	@echo "[pi] Building..."
-	@$(GO) build -o $(BIN)
+	@$(GO) build -o $(BIN)-$(VERSION)-darwin \
+		-ldflags "-X main.operatorVersion=$(GIT_SHA) -X github.com/WiseGrowth/go-wisebot/logger.environment=production -X main.version=$(VERSION) -X main.baseURL=$(BASE_URL)"
+
+build-uploader:
+	@$(GO) build -o $(BIN_FOLDER)/$(UPLOADER_APP)-darwin \
+		-ldflags "-X main.filename=$(APP) -X main.filepath=$(BIN_FOLDER) -X main.bucket=$(BUCKET_RELEASES) -X main.region=$(REGION)" $(PWD)/$(UPLOADER_APP)/main.go
 
 run r: build
 	@echo "[run] Running..."
@@ -22,11 +36,25 @@ clean:
 	@echo "[clean] Removing $(BIN)..."
 	@rm -rf $(BIN)
 
+clean-all:
+	@echo "[clean] Removing $(BIN)..."
+	@rm -rf $(BIN_FOLDER)/*
+
 upload:
 	@echo "[upload] Starting..."
+	@cp $(BIN)-$(VERSION) $(BIN)
 	@scp $(BIN) pi@$(PI_IP):~
+	@rm $(BIN)
 	@echo "[upload] Done"
 
 deploy: pi upload
 
-.PHONY: pi build b clean upload deploy run
+checksum:
+	@echo "[Checksum] Generating $(APP) Checksum..."
+	@$(OPENSSL) sha256 $(BIN)-$(VERSION) | awk '{print $$2}' > $(BIN)-$(VERSION).checksum
+
+new-release: pi checksum
+	@echo "[New Release] Uploading new release to AWS S3 Bucket..."
+	@$(UPLOADER_BIN)-darwin $(VERSION)
+
+.PHONY: pi build b clean upload deploy run checksum new-release clean-all

--- a/git/repo.go
+++ b/git/repo.go
@@ -242,6 +242,30 @@ func YarnInstallHook(r *Repo) error {
 	return nil
 }
 
+// NpmInstallHook is a PostReceiveHook preset that runs a
+// `npm install --production` command.
+func NpmInstallHook(r *Repo) error {
+	var bout bytes.Buffer
+	var berr bytes.Buffer
+
+	npmInstall := exec.Command("npm", "install", "--production")
+	npmInstall.Dir = r.Path
+	npmInstall.Stdout = &bout
+	npmInstall.Stderr = &berr
+
+	if err := npmInstall.Run(); err != nil {
+		r.logger().WithFields(logrus.Fields{
+			"stdout": bout.String(),
+			"stderr": berr.String(),
+			"err":    err.Error(),
+		}).Debug("Error when running npm install")
+
+		return err
+	}
+
+	return nil
+}
+
 // NpmPruneHook is a PostReceiveHook preset that runs a `npm prune` command.
 func NpmPruneHook(r *Repo) error {
 	var bout bytes.Buffer

--- a/process_manager.go
+++ b/process_manager.go
@@ -10,28 +10,28 @@ import (
 // ProcessManager is in charge of starting and stoping the processes.
 type ProcessManager struct {
 	sync.Mutex
-	Services                  *ServiceStore
-	MQTTClient                *iot.Client
-	servicesAndDaemonsStarted bool
-	mqttConnectionStarted     bool
+	Services              *ServiceStore
+	MQTTClient            *iot.Client
+	servicesStarted       bool
+	mqttConnectionStarted bool
 }
 
-// KickOffServicesAndDaemons is a function that kicks off core subprocesses
+// KickOffServices is a function that kicks off core subprocesses
 // managed by the operator. `hasInternetConnection` param indicates wether the
 // subprocesses and daemons source code can be updated by git or not.
 // The subprocesses knows how to reconnect when they lose internet connection,
 // so is not necessary to start them while being connected to the internet.
 // The wrong value of `hasInternetConnection` can raise errors, so is mandatory
 // to check if the device is online before executing this method.
-func (pm *ProcessManager) KickOffServicesAndDaemons(hasInternetConnection bool) error {
+func (pm *ProcessManager) KickOffServices(hasInternetConnection bool) error {
 	pm.Lock()
 	defer pm.Unlock()
 
 	log := logger.GetLogger()
 	log.Debug("Bootstraping and starting services")
 
-	if pm.servicesAndDaemonsStarted {
-		log.Debug("Process already started, ignoring KickOffServicesAndDaemons()")
+	if pm.servicesStarted {
+		log.Debug("Process already started, ignoring KickOffServices()")
 		return nil
 	}
 
@@ -39,7 +39,7 @@ func (pm *ProcessManager) KickOffServicesAndDaemons(hasInternetConnection bool) 
 		return err
 	}
 
-	pm.servicesAndDaemonsStarted = true
+	pm.servicesStarted = true
 
 	log.Debug("Bootstraping done")
 	return nil
@@ -120,6 +120,9 @@ func (pm *ProcessManager) bootstrapMQTTClient() error {
 	if err := pm.MQTTClient.Subscribe("/operator/"+wisebotConfig.WisebotID+"/service-update", updateServiceMQTTHandler); err != nil {
 		return err
 	}
+	if err := pm.MQTTClient.Subscribe("/operator/"+wisebotConfig.WisebotID+"/service-restart", restartServiceMQTTHandler); err != nil {
+		return err
+	}
 	if err := pm.MQTTClient.Subscribe("/operator/"+wisebotConfig.WisebotID+"/daemon-start", startDaemonMQTTHandler); err != nil {
 		return err
 	}
@@ -130,6 +133,9 @@ func (pm *ProcessManager) bootstrapMQTTClient() error {
 		return err
 	}
 	if err := pm.MQTTClient.Subscribe("/operator/"+wisebotConfig.WisebotID+"/daemon-restart", restartDaemonMQTTHandler); err != nil {
+		return err
+	}
+	if err := pm.MQTTClient.Subscribe("/operator/"+wisebotConfig.WisebotID+"/update", updateOperatorMQTTHandler); err != nil {
 		return err
 	}
 

--- a/services.go
+++ b/services.go
@@ -307,8 +307,7 @@ func (ss *ServiceStore) RestartService(name string) error {
 		return err
 	}
 
-	cmd := svc.cmd
-	cmd = cmd.Clone()
+	cmd := svc.cmd.Clone()
 	ss.Save(svc.Name, cmd, svc.repo)
 
 	defer svc.logger().Info("Restarted")

--- a/updater.go
+++ b/updater.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"crypto"
+	"encoding/hex"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/WiseGrowth/go-wisebot/logger"
+	update "github.com/inconshreveable/go-update"
+)
+
+// Updater is in charge to update the operator
+type Updater struct {
+	uploading bool
+	baseURL   string
+	version   string
+}
+
+// NewUpdate constructor method for Updater struct
+func NewUpdate(baseURL string, currentVersion string) *Updater {
+	return &Updater{uploading: false, baseURL: baseURL, version: currentVersion}
+}
+
+// Update method used for update this operator service based of param version
+func (up *Updater) Update(newVersion string) error {
+	//TODO: validate newVersion format, eg. 1.2.3
+	if newVersion == up.version {
+		err := errors.New("new version is the same that currently exists in the service")
+		return err
+	}
+
+	up.uploading = true
+
+	var urlChecksum = up.baseURL + newVersion + ".checksum"
+	var urlBin = up.baseURL + newVersion
+
+	log := logger.GetLogger()
+	log.Info("New Version: ", newVersion)
+	log.Info("URL Checksum: ", urlChecksum)
+	log.Info("URL Bin: ", urlBin)
+
+	//define http client
+	client := http.Client{}
+
+	//get checksum file
+	log.Info("[Download Checksum]")
+	respChecksum, err := client.Get(urlChecksum)
+	if err != nil {
+		return err
+	}
+	if respChecksum.StatusCode != 200 {
+		msg := "Checksum file not available to " + newVersion
+		err := errors.New(msg)
+		return err
+	}
+	log.Info("[Download Checksum] ready...")
+
+	//get checksum value
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(respChecksum.Body)
+	checksum := buf.String()
+	checksum = strings.TrimSpace(checksum)
+	respChecksum.Body.Close()
+
+	//get binary
+	log.Info("[Download Binary]")
+	respBin, err := client.Get(urlBin)
+	if err != nil {
+		return err
+	}
+	if respBin.StatusCode != 200 {
+		msg := "Checksum file not available to " + newVersion
+		err := errors.New(msg)
+		return err
+	}
+	log.Info("[Download Binary] ready...")
+
+	//update binary
+	log.Info("[Upload Version]")
+	err = up.updateWithChecksum(respBin.Body, checksum)
+	if err != nil {
+		log.Error(err)
+	}
+	respBin.Body.Close()
+	log.Info("[Upload Version] Ready")
+
+	up.uploading = false
+	return err
+}
+
+func (up *Updater) updateWithChecksum(binary io.Reader, hexChecksum string) error {
+	checksum, err := hex.DecodeString(hexChecksum)
+	if err != nil {
+		return err
+	}
+
+	err = update.Apply(binary, update.Options{
+		Hash:     crypto.SHA256,
+		Checksum: checksum,
+	})
+
+	return err
+}

--- a/uploader/main.go
+++ b/uploader/main.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+)
+
+var (
+	region   string
+	filename string
+	filepath string
+	bucket   string
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Version is require", os.Args[0])
+		return
+	}
+	version := os.Args[1]
+
+	// create new session
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String(region)},
+	)
+
+	// define filenames
+	binaryFile := filename + "-" + version
+	checksumFile := filename + "-" + version + ".checksum"
+
+	// create an uploader with the session
+	fmt.Println("[aws] connecting...")
+	uploader := s3manager.NewUploader(sess)
+
+	//open binary file
+	bin, err := os.Open(filepath + "/" + binaryFile)
+	if err != nil {
+		fmt.Println("[error] failed to open file ", binaryFile, err)
+		return
+	}
+
+	//open checksum file
+	checksum, err := os.Open(filepath + "/" + checksumFile)
+	if err != nil {
+		fmt.Println("[error] failed to open file ", checksumFile, err)
+		return
+	}
+
+	// TODO: check if binary file exist inside bucket
+	fmt.Println("[aws] uploading bin...")
+	binResult, err := uploader.Upload(&s3manager.UploadInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(binaryFile),
+		Body:   bin,
+	})
+	if err != nil {
+		fmt.Println("[error] failed to upload file ", err)
+		return
+	}
+
+	// TODO: check if checksum file exist inside bucket
+	// TODO: make public uploaded files
+	fmt.Println("[aws] uploading checksum...")
+	checksumResult, err := uploader.Upload(&s3manager.UploadInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(checksumFile),
+		Body:   checksum,
+	})
+	if err != nil {
+		fmt.Println("[error] failed to upload file ", err)
+		return
+	}
+
+	fmt.Println("[ready] binary file", binResult.Location)
+	fmt.Println("[ready] checksum file", checksumResult.Location)
+}


### PR DESCRIPTION
Implementation for auto self updating

Features:
* Possibility of upgrade to mayor version
* Possibility for downgrade to minnor version.
* Custom encryptation. Now SHA256
* Uploader new operator: upload a specific operator version to S3 bucket. **This command overwrites the current bucket file. See attached image**
`./bin/uploader <version>`
* MQTT Implementation. `/update {version}`
* HTTP Implementation. `[POST] /update {version}`
* Makefile new commands:
    * clean-all: remove all files to bin folder
    * new-release: build pi operator and upload to S3 with checksum file
    * build-uploader: in charge to compile the uploader
    * checksum: in charge to generate a checksum file with respective version

On the other hand, now it has support for the route `/restart-service` (POST method in the case of HTTP) service through the HTTP and MQTT protocols.

----------------------

<img width="408" alt="screen shot 2018-01-23 at 17 34 30" src="https://user-images.githubusercontent.com/8485620/35299386-e7dafe96-0063-11e8-8740-7f83aaaffe93.png">
